### PR TITLE
Added CMakeLists.txt in theme overrides

### DIFF
--- a/icon_themes/catppuccin-icons.json
+++ b/icon_themes/catppuccin-icons.json
@@ -1707,7 +1707,8 @@
         "README.txt": "readme",
         "Makefile": "makefile",
         "Caddyfile": "caddy",
-        ".DS_Store": "macos"
+        ".DS_Store": "macos",
+        "CMakeLists.txt": "cmake"
       },
       "file_suffixes": {
         "Rproj": "rproj",
@@ -6386,7 +6387,8 @@
         "README.txt": "readme",
         "Makefile": "makefile",
         "Caddyfile": "caddy",
-        ".DS_Store": "macos"
+        ".DS_Store": "macos",
+        "CMakeLists.txt": "cmake"
       },
       "file_suffixes": {
         "Rproj": "rproj",
@@ -11065,7 +11067,8 @@
         "README.txt": "readme",
         "Makefile": "makefile",
         "Caddyfile": "caddy",
-        ".DS_Store": "macos"
+        ".DS_Store": "macos",
+        "CMakeLists.txt": "cmake"
       },
       "file_suffixes": {
         "Rproj": "rproj",
@@ -15744,7 +15747,8 @@
         "README.txt": "readme",
         "Makefile": "makefile",
         "Caddyfile": "caddy",
-        ".DS_Store": "macos"
+        ".DS_Store": "macos",
+        "CMakeLists.txt": "cmake"
       },
       "file_suffixes": {
         "Rproj": "rproj",

--- a/src/build.ts
+++ b/src/build.ts
@@ -24,6 +24,7 @@ const THEME_OVERRIDES = {
     Makefile: "makefile",
     Caddyfile: "caddy",
     ".DS_Store": "macos",
+    "CMakeLists.txt": "cmake",
   },
 };
 


### PR DESCRIPTION
closes #44.

`CMakeLists.txt` files now appear with the right icon.

<img width="325" height="102" alt="Screenshot_20250926_092113" src="https://github.com/user-attachments/assets/6c5d09ac-b844-4fbd-bfbe-b77b2358e7fd" />
