### PR TITLE
feat: Add 'avsc' icon paths to theme JSON files

### DIFF
--- a/icon_themes/catppuccin-icons.json
+++ b/icon_themes/catppuccin-icons.json
@@ -4009,6 +4009,9 @@
         "json": {
           "path": "./icons/latte/json.svg"
         },
+        "avsc": {
+          "path": "./icons/latte/json.svg"
+        },
         "juce": {
           "path": "./icons/latte/juce.svg"
         },
@@ -8708,6 +8711,9 @@
           "path": "./icons/frappe/json-schema.svg"
         },
         "json": {
+          "path": "./icons/frappe/json.svg"
+        },
+         "avsc": {
           "path": "./icons/frappe/json.svg"
         },
         "juce": {
@@ -13411,6 +13417,9 @@
         "json": {
           "path": "./icons/macchiato/json.svg"
         },
+         "avsc": {
+          "path": "./icons/macchiato/json.svg"
+        },
         "juce": {
           "path": "./icons/macchiato/juce.svg"
         },
@@ -18110,6 +18119,9 @@
           "path": "./icons/mocha/json-schema.svg"
         },
         "json": {
+          "path": "./icons/mocha/json.svg"
+        },
+        "avsc": {
           "path": "./icons/mocha/json.svg"
         },
         "juce": {


### PR DESCRIPTION
I just added support for .avsc files to follow the same patterns as JSON, both here and in vscode-icons. I’m going to open a PR there as well and I hope you’ll accept it! Thanks.