### PR TITLE
fix: map Angular file suffixes to existing icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@
 3. Search for the _Catppuccin Icons_ extension and install.
 4. Enter _icon theme selector: toggle_ in the command palette and select the Catppuccin Icons theme in your preferred flavor in the dropdown.
 
+Angular files ending in `.component.ts`, `.directive.ts`, `.guard.ts`, `.pipe.ts`,
+or `.service.ts` use their corresponding Angular icons automatically. Other `.ts`
+files keep the TypeScript icon.
+
 ## Development
 
 <details>

--- a/icon_themes/catppuccin-icons.json
+++ b/icon_themes/catppuccin-icons.json
@@ -1718,6 +1718,11 @@
         "RData": "rdata",
         "Rhistory": "r",
         "Dockerfile": "docker",
+        "component.ts": "angular-component",
+        "directive.ts": "angular-directive",
+        "guard.ts": "angular-guard",
+        "pipe.ts": "angular-pipe",
+        "service.ts": "angular-service",
         "fbx": "3d",
         "glb": "3d",
         "gltf": "3d",
@@ -4009,9 +4014,6 @@
         "json": {
           "path": "./icons/latte/json.svg"
         },
-        "avsc": {
-          "path": "./icons/latte/json.svg"
-        },
         "juce": {
           "path": "./icons/latte/juce.svg"
         },
@@ -4698,6 +4700,24 @@
         },
         "zip": {
           "path": "./icons/latte/zip.svg"
+        },
+        "angular-component": {
+          "path": "./icons/latte/angular-component.svg"
+        },
+        "angular-directive": {
+          "path": "./icons/latte/angular-directive.svg"
+        },
+        "angular-guard": {
+          "path": "./icons/latte/angular-guard.svg"
+        },
+        "angular-pipe": {
+          "path": "./icons/latte/angular-pipe.svg"
+        },
+        "angular-service": {
+          "path": "./icons/latte/angular-service.svg"
+        },
+        "avsc": {
+          "path": "./icons/latte/json.svg"
         },
         "lock": {
           "path": "./icons/latte/lock.svg"
@@ -6422,6 +6442,11 @@
         "RData": "rdata",
         "Rhistory": "r",
         "Dockerfile": "docker",
+        "component.ts": "angular-component",
+        "directive.ts": "angular-directive",
+        "guard.ts": "angular-guard",
+        "pipe.ts": "angular-pipe",
+        "service.ts": "angular-service",
         "fbx": "3d",
         "glb": "3d",
         "gltf": "3d",
@@ -8713,9 +8738,6 @@
         "json": {
           "path": "./icons/frappe/json.svg"
         },
-         "avsc": {
-          "path": "./icons/frappe/json.svg"
-        },
         "juce": {
           "path": "./icons/frappe/juce.svg"
         },
@@ -9402,6 +9424,24 @@
         },
         "zip": {
           "path": "./icons/frappe/zip.svg"
+        },
+        "angular-component": {
+          "path": "./icons/frappe/angular-component.svg"
+        },
+        "angular-directive": {
+          "path": "./icons/frappe/angular-directive.svg"
+        },
+        "angular-guard": {
+          "path": "./icons/frappe/angular-guard.svg"
+        },
+        "angular-pipe": {
+          "path": "./icons/frappe/angular-pipe.svg"
+        },
+        "angular-service": {
+          "path": "./icons/frappe/angular-service.svg"
+        },
+        "avsc": {
+          "path": "./icons/frappe/json.svg"
         },
         "lock": {
           "path": "./icons/frappe/lock.svg"
@@ -11126,6 +11166,11 @@
         "RData": "rdata",
         "Rhistory": "r",
         "Dockerfile": "docker",
+        "component.ts": "angular-component",
+        "directive.ts": "angular-directive",
+        "guard.ts": "angular-guard",
+        "pipe.ts": "angular-pipe",
+        "service.ts": "angular-service",
         "fbx": "3d",
         "glb": "3d",
         "gltf": "3d",
@@ -13417,9 +13462,6 @@
         "json": {
           "path": "./icons/macchiato/json.svg"
         },
-         "avsc": {
-          "path": "./icons/macchiato/json.svg"
-        },
         "juce": {
           "path": "./icons/macchiato/juce.svg"
         },
@@ -14106,6 +14148,24 @@
         },
         "zip": {
           "path": "./icons/macchiato/zip.svg"
+        },
+        "angular-component": {
+          "path": "./icons/macchiato/angular-component.svg"
+        },
+        "angular-directive": {
+          "path": "./icons/macchiato/angular-directive.svg"
+        },
+        "angular-guard": {
+          "path": "./icons/macchiato/angular-guard.svg"
+        },
+        "angular-pipe": {
+          "path": "./icons/macchiato/angular-pipe.svg"
+        },
+        "angular-service": {
+          "path": "./icons/macchiato/angular-service.svg"
+        },
+        "avsc": {
+          "path": "./icons/macchiato/json.svg"
         },
         "lock": {
           "path": "./icons/macchiato/lock.svg"
@@ -15830,6 +15890,11 @@
         "RData": "rdata",
         "Rhistory": "r",
         "Dockerfile": "docker",
+        "component.ts": "angular-component",
+        "directive.ts": "angular-directive",
+        "guard.ts": "angular-guard",
+        "pipe.ts": "angular-pipe",
+        "service.ts": "angular-service",
         "fbx": "3d",
         "glb": "3d",
         "gltf": "3d",
@@ -18121,9 +18186,6 @@
         "json": {
           "path": "./icons/mocha/json.svg"
         },
-        "avsc": {
-          "path": "./icons/mocha/json.svg"
-        },
         "juce": {
           "path": "./icons/mocha/juce.svg"
         },
@@ -18810,6 +18872,24 @@
         },
         "zip": {
           "path": "./icons/mocha/zip.svg"
+        },
+        "angular-component": {
+          "path": "./icons/mocha/angular-component.svg"
+        },
+        "angular-directive": {
+          "path": "./icons/mocha/angular-directive.svg"
+        },
+        "angular-guard": {
+          "path": "./icons/mocha/angular-guard.svg"
+        },
+        "angular-pipe": {
+          "path": "./icons/mocha/angular-pipe.svg"
+        },
+        "angular-service": {
+          "path": "./icons/mocha/angular-service.svg"
+        },
+        "avsc": {
+          "path": "./icons/mocha/json.svg"
         },
         "lock": {
           "path": "./icons/mocha/lock.svg"

--- a/src/build.ts
+++ b/src/build.ts
@@ -78,6 +78,11 @@ try {
     RData: "rdata",
     Rhistory: "r",
     Dockerfile: "docker",
+    "component.ts": "angular-component",
+    "directive.ts": "angular-directive",
+    "guard.ts": "angular-guard",
+    "pipe.ts": "angular-pipe",
+    "service.ts": "angular-service",
   };
   for (const [vsCodeFileIcons_key, vscodeFileIcons_value] of Object.entries(
     fileIcons,
@@ -107,6 +112,12 @@ try {
 
   // stage 2: compile flavor specific properties
   const FILE_ICON_OVERRIDES = {
+    "angular-component": "angular-component",
+    "angular-directive": "angular-directive",
+    "angular-guard": "angular-guard",
+    "angular-pipe": "angular-pipe",
+    "angular-service": "angular-service",
+    avsc: "json",
     lock: "lock",
     settings: "config",
   };


### PR DESCRIPTION
Files such as `app.component.ts` and `auth.service.ts` currently use the generic TypeScript icon despite the Angular SVGs already shipping with the extension. Add compound-suffix mappings and register the existing component, directive, guard, pipe, and service icons through the generator's override tables for all four flavors. Document the filename conventions in the README.

Preserve the existing `avsc` → JSON icon alias in the generator, since rebuilding otherwise removes the manually added alias from the generated themes.

Closes #54.

Validation:
- `just build` succeeds.
- Checked all 20 new associations and their SVG paths across the four flavors.
- Compared parsed generated themes against the base: all pre-existing theme data is unchanged, and the lockfile is unchanged.
- `git diff --check` passes.
- `deno fmt --check src/build.ts` reports existing loop formatting differences, also reproduced on the unmodified base file.
- Zed UI rendering was not manually tested.
