### PR TITLE
chore(deps): update Deno lockfile to version 5

### DIFF
--- a/src/deno.lock
+++ b/src/deno.lock
@@ -1,17 +1,11 @@
 {
-  "version": "4",
+  "version": "5",
   "specifiers": {
-    "jsr:@catppuccin/palette@^1.7.1": "1.7.1",
-    "npm:jquery@*": "3.7.1"
+    "jsr:@catppuccin/palette@^1.7.1": "1.7.1"
   },
   "jsr": {
     "@catppuccin/palette@1.7.1": {
       "integrity": "91238ec1bb04420196f27422ec75bc53aaece6d4896628f053aa8335502316f1"
-    }
-  },
-  "npm": {
-    "jquery@3.7.1": {
-      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
     }
   },
   "workspace": {


### PR DESCRIPTION
Regenerate `src/deno.lock` with Deno 2.9.6 in version 5 format. Renovate's Deno manager rejects lockfile versions below 5 with an unsupported-version warning, so version 4 prevents it from reading locked dependency versions.

The palette stays at 1.7.1 with the same integrity hash. Regeneration from the build and test entrypoints removes the unused jQuery lock entry. No application or generated theme changes.

Validation:
- `just build` passes and leaves generated themes and icons unchanged.
- `cd src && deno test --allow-read --frozen build_test.ts` passes.
- `cd src && deno install --frozen --lockfile-only` passes without changes.
- Verified the lockfile satisfies Renovate's current minimum-version check and retains the palette resolution and integrity.
- `git diff --check` passes.

The hosted Renovate run has not been rerun; confirmation that the warning disappears will follow its next run after merge.
