### PR TITLE
chore(release): bump version to 1.24.0

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "catppuccin-icons"
 name = "Catppuccin Icons"
-version = "1.23.1"
+version = "1.24.0"
 schema_version = 1
 authors = ["Catppuccin <releases@catppuccin.com>"]
 description = "🦊 Soothing pastel icons for Zed"


### PR DESCRIPTION
Bump the extension version to 1.24.0 for the next release, including the merged monochrome theme variants and Angular icon associations.

Validation: `just build` and `cd src && deno test --allow-read --frozen build_test.ts` pass. Regeneration leaves the checked-in themes and icons unchanged; only `extension.toml` changes.
